### PR TITLE
Disable unnecessary Bevy features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ pollster = "0.3.0"
 
 [dependencies.bevy]
 version = "0.14"
+default-features = false
+features = ["bevy_render"]


### PR DESCRIPTION
TL;DR disables default features and enables `bevy_render`.

Since this crate relies purely on the `bevy_render` crate, we can disable Bevy's default features and enable it manually instead. This prevents us from compiling an extra 60 crates and a few minutes (at least on my system!) when building for headless.